### PR TITLE
feat: Add base config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ custom:
     bundlerBin: /path/to/bundler
 ```
 
+If your app entrypoint `config.ru` file is not in `./`, set the path & filename explicitly using the `baseConfigFile`
+configuration option:
+
+```yaml
+custom:
+  rack:
+    baseConfigFile: /path/to/config.ru
+```
+
 ### Local server
 
 For convenience, a `sls rack serve` command is provided to run your Rack application

--- a/index.js
+++ b/index.js
@@ -88,6 +88,15 @@ class ServerlessRack {
     ) {
       config.text_mime_types = this.serverless.service.custom.rack.textMimeTypes;
     }
+    if (
+      this.serverless.service.custom &&
+      this.serverless.service.custom.rack &&
+      _.isString(this.serverless.service.custom.rack.baseConfigFile)
+    ) {
+      config.base_config_file = this.serverless.service.custom.rack.baseConfigFile;
+    } else {
+      config.base_config_file = "config.ru";
+    }
 
     return config;
   }

--- a/lib/rack_adapter.rb
+++ b/lib/rack_adapter.rb
@@ -13,8 +13,13 @@ require 'rack'
 
 require_relative './serverless_rack'
 
-$app ||= Rack::Builder.parse_file('config.ru').first
 $config ||= JSON.parse(File.read('.serverless-rack'))
+app_path =  if $config['base_config_file']
+              $config['base_config_file'].to_s
+            else
+              'config.ru'
+            end
+$app ||= Rack::Builder.parse_file(app_path).first
 
 # For some reason, SimpleCov is unable to profile this file correctly.
 # It is covered, though, but you'll need to take my word for it.


### PR DESCRIPTION
Hi,

Just wondered if you would be interested in a proposal to include the ability to custom configure the config_base for the app.

I have got this working with the pact_broker app, however I pull in the config from another repo, into a pact_broker folder, and rather than changing any references in that code, it would be handy to change the config base.

This is a bit of a hack for now, but it worked, happy to make it a bit cleaner, and more in link with existing rack custom vars if you would be happy to consider

PS, thank you for the great project and top docs!

Thanks!