### PR TITLE
Properly log error from failed child process

### DIFF
--- a/index.js
+++ b/index.js
@@ -390,7 +390,7 @@ class ServerlessRack {
           }
 
           if (res.status != 0) {
-            return reject(res.stdout);
+            return reject(res.stdout.toString() || res.stderr.toString());
           }
         }
       } else {


### PR DESCRIPTION
On my machine, my build was failing with 

```
  Error --------------------------------------------------
< Buffer >
```

The error was because Docker wasn't running, but the reason for the cryptic error message was twofold:
1. The `spawnSync` method's return value has `stdout` and `stderr` as [`string | Buffer`](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options), so we need to cast to string before passing along.
2. The error message in my case was in stderr. out was an empty Buffer:
```
{
  status: 127,
  signal: null,
  output: [
    null,
    <Buffer >,
    <Buffer 64 6f 63 6b 65 72 3a 20 65 72 72 6f 72 20 64 75 72 69 6e 67 20 63 6f 6e 6e 65 63 74 3a 20 54 68 69 73 20 65 72 72 6f 72 20 6d 61 79 2
0 69 6e 64 69 63 ... 209 more bytes>
  ],
  pid: 1380,
  stdout: <Buffer >,
  stderr: <Buffer 64 6f 63 6b 65 72 3a 20 65 72 72 6f 72 20 64 75 72 69 6e 67 20 63 6f 6e 6e 65 63 74 3a 20 54 68 69 73 20 65 72 72 6f 72 20 6d 6
1 79 20 69 6e 64 69 63 ... 209 more bytes>
}
```

This PR fixes both these issues: stdout will be used if non-empty, and fallback to stderr. Any buffers are cast to string. No BC breaks.