### PR TITLE
Display output from child Docker process

### DIFF
--- a/index.js
+++ b/index.js
@@ -378,7 +378,9 @@ class ServerlessRack {
           args.push(this.dockerImage);
           args.push(...this.dockerArgs);
 
-          const res = child_process.spawnSync("docker", args);
+          const res = child_process.spawnSync("docker", args, {
+            stdio: "inherit"
+          });
           if (res.error) {
             if (res.error.code == "ENOENT") {
               return reject(


### PR DESCRIPTION
On running this for the first time, I didn't have the `'logandk/serverless-rack-bundler` image locally, so Docker of course had to pull it first. Unfortunately, Docker's stdout wasn't being displayed, so I was left staring at `Serverless: Packaging gem dependencies using docker...` and wondering if something had broken. This PR makes sure the user knows what's going on with Docker behind the scenes.