### PR TITLE
Don't cleanup automatically

### DIFF
--- a/index.js
+++ b/index.js
@@ -760,8 +760,7 @@ class ServerlessRack {
       BbPromise.bind(this)
         .then(this.validate)
         .then(this.saveDockerCache)
-        .then(this.restoreBundle)
-        .then(this.cleanup);
+        .then(this.restoreBundle);
 
     this.hooks = {
       "rack:rack": () => {
@@ -814,8 +813,6 @@ class ServerlessRack {
           return BbPromise.resolve();
         }
       },
-      "after:invoke:local:invoke": () =>
-        BbPromise.bind(this).then(this.cleanup),
     };
   }
 }


### PR DESCRIPTION
I noticed that whenever I run `sls invoke` or `sls offline`, the `serverless_rack` and `rack_adapter` files are deleted. This is extremely frustrating, as it means I have to run `rack install` *every time I wish to test my function*, which is a pretty expensive operation—I'm not using Docker, and it takes up to two minutes at times, slowing down my entire workflow.

There isn't really a need for this, IMO. I think cleanup should be left to the end user.