### PR TITLE
Add require stringio

### DIFF
--- a/lib/rack_adapter.rb
+++ b/lib/rack_adapter.rb
@@ -10,6 +10,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'json'
 require 'rack'
+require 'stringio'
 
 require_relative './serverless_rack'
 

--- a/lib/serverless_rack.rb
+++ b/lib/serverless_rack.rb
@@ -6,6 +6,7 @@
 
 require 'rack'
 require 'base64'
+require 'stringio'
 
 TEXT_MIME_TYPES = [
   'application/json',


### PR DESCRIPTION
Fix StringIO Exception when using serverless offline with simple rack application.

### Steps to reproduce
* Gemfile
```ruby
source 'https://rubygems.org'
git_source(:github) { |repo| "https://github.com/#{repo}.git" }

ruby '~> 2.7'

gem 'rack'
```
* config.ru
```ruby
class TestApp
  def call(env)
    status  = 200
    headers = { "Content-Type" => "text/html" }
    body    = ["Hello World!"]

    [status, headers, body]
  end
end

run TestApp.new
```

* serverless.yml
```yaml
service: sls-test
frameworkVersion: '3'

provider:
  name: aws
  runtime: ruby2.7

functions:
  api:
    handler: rack_adapter.handler
    events:
      - http: GET /

plugins:
  - serverless-rack
  - serverless-offline
```

```shell
$ sls rack install
$ sls offline
$ curl http://localhost:3000/dev
...
GET /dev (λ: api)
✖ Command failed with exit code 1: ruby /home/bongole/dev/sls-test/node_modules/serverless-offline/dist/lambda/handler-runner/ruby-runner/invoke.rb rack_adapter handler
  /home/bongole/dev/sls-test/serverless_rack.rb:100:in `build_environ': uninitialized constant StringIO (NameError)
        from /home/bongole/dev/sls-test/serverless_rack.rb:227:in `handle_request'
        from /home/bongole/dev/sls-test/rack_adapter.rb:63:in `handler'
        from /home/bongole/dev/sls-test/node_modules/serverless-offline/dist/lambda/handler-runner/ruby-runner/invoke.rb:83:in `<main>'

```