### PR TITLE
Add user flag to docker option

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,6 +372,11 @@ class ServerlessRack {
             `${this.serverless.config.servicePath}:/var/task`,
           ];
 
+          const {uid, gid} = os.userInfo();
+          if( 0 <= uid && 0 <= gid ){ // uid == -1 and gid == -1 on Windows
+            args.push("--user", `${uid}:${gid}`);
+          }
+
           if (this.bundlerArgs) {
             args.push("-e", `BUNDLER_ARGS=${this.bundlerArgs}`);
           }


### PR DESCRIPTION
sls rack install with lambci/lambda:build-ruby2.7 image makes vendor/ and .bundle/ directory owner as root.
Add user flag to docker option to fix it. 

### Steps to reproduce
* serverless.yml
```yaml
service: sls-test
frameworkVersion: '3'

provider:
  name: aws
  runtime: ruby2.7

functions:
  api:
    handler: rack_adapter.handler
    events:
      - http: GET /

plugins:
  - serverless-rack

custom:
  rack:
    dockerImage: lambci/lambda:build-ruby2.7
    dockerizeBundler: true
    bundlerArgs: --no-cache
```

```shell
$ sls rack install
$ ls -lah
total 508K
drwxr-xr-x   6 bongole bongole 4.0K Apr  3 16:23 .
drwxr-xr-x 166 bongole bongole 4.0K Apr  3 15:53 ..
drwxr-xr-x   2 root    root    4.0K Apr  3 16:23 .bundle   # owner is root
-rw-r--r--   1 bongole bongole    6 Apr  3 15:55 .ruby-version
-rw-r--r--   1 bongole bongole    2 Apr  3 16:23 .serverless-rack
drwxr-xr-x   2 bongole bongole 4.0K Apr  3 16:23 .serverless-rack-temp
-rw-r--r--   1 bongole bongole  121 Apr  3 15:55 Gemfile
-rw-r--r--   1 bongole bongole  143 Apr  3 16:23 Gemfile.lock
-rw-r--r--   1 bongole bongole  183 Apr  3 15:55 config.ru
drwxr-xr-x 447 bongole bongole  20K Apr  3 15:57 node_modules
-rw-r--r--   1 bongole bongole 426K Apr  3 15:57 package-lock.json
-rw-r--r--   1 bongole bongole   99 Apr  3 15:54 package.json
-rw-r--r--   1 bongole bongole 1.7K Apr  3 16:23 rack_adapter.rb
-rw-r--r--   1 bongole bongole  338 Apr  3 16:22 serverless.yml
-rw-r--r--   1 bongole bongole 6.2K Apr  3 16:23 serverless_rack.rb
drwxr-xr-x   3 root    root    4.0K Apr  3 16:23 vendor  # owner is root
```