### PR TITLE
Fix double-escaped query string

### DIFF
--- a/lib/serverless_rack.rb
+++ b/lib/serverless_rack.rb
@@ -45,9 +45,9 @@ end
 
 def parse_query_string(event)
   if event.include? 'multiValueQueryStringParameters'
-    Rack::Utils.build_query(event['multiValueQueryStringParameters'] || {})
+    Rack::Utils.unescape(Rack::Utils.build_query(event['multiValueQueryStringParameters'] || {}))
   else
-    Rack::Utils.build_query(event['queryStringParameters'] || {})
+    Rack::Utils.unescape(Rack::Utils.build_query(event['queryStringParameters'] || {}))
   end
 end
 

--- a/spec/rack_adapter_spec.rb
+++ b/spec/rack_adapter_spec.rb
@@ -180,6 +180,31 @@ RSpec.describe 'Rack adapter' do
     )
   end
 
+  it 'handles escaped characters in parameters' do
+    @event['queryStringParameters'] = { 'param1' => 'value%231', 'param2' => 'value%232' }
+
+    handler(
+      event: @event,
+      context: { 'memory_limit_in_mb' => '128' }
+    )
+
+    expect(@app.last_environ['QUERY_STRING']).to eq('param1=value%231&param2=value%232')
+  end
+
+  it 'handles escaped characters in multi-value query string parameters' do
+    @event['multiValueQueryStringParameters'] = {
+      'param1' => ['value%231'],
+      'param2' => %w[value%232 value%233]
+    }
+
+    handler(
+      event: @event,
+      context: { 'memory_limit_in_mb' => '128' }
+    )
+
+    expect(@app.last_environ['QUERY_STRING']).to eq('param1=value%231&param2=value%232&param2=value%233')
+  end
+
   it 'handles a request in china region' do
     @event['headers']['Host'] = 'x.amazonaws.com.cn'
 


### PR DESCRIPTION
Issue https://github.com/logandk/serverless-rack/issues/19 from last year was perhaps badly worded, and didn't describe the problem correctly.

Given the URL `http://localhost?param1=value%231` (`param1 = value#1`)

The event passed to the lambda contains the string already escaped:

```ruby
"multiValueQueryStringParameters"=>{"param1"=>["value%231"]}
```

But using `Rack::Utils.build_query` will escape the percent symbol again. This is the output from running the additional tests without the fix:

```
       expected: "param1=value%231&param2=value%232"
            got: "param1=value%25231&param2=value%25232"
```

Escaping the returned string fixes the issue.

The one bit I wasn't clear about in my original query; we are only using serverless rack in AWS - we're not using it locally (we're not using serverless locally at all, just straight ruby / rack). It sounded like we were getting different behaviour from the gem between local machines and AWS, when we're actually not using the gem locally at all - thus the different behaviour.