### PR TITLE
Ensure for events containing multiValueHeaders, the Rack::Headers return object is correctly initialised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.1
+
+- Correctly initialise `Rack::Headers` instance for events containing `multiValueHeaders`
+  _Matthew Pickin_
+
 # 2.0.0
 
 - Add support for Rack v3 (#44)

--- a/lib/serverless_rack.rb
+++ b/lib/serverless_rack.rb
@@ -65,11 +65,11 @@ end
 
 def parse_headers(event)
   if event.include? 'multiValueHeaders'
-    Rack::Headers.new(
+    Rack::Headers[
       (event['multiValueHeaders'] || {}).transform_values do |value|
         value.join("\n")
       end
-    )
+    ]
   else
     Rack::Headers[event['headers'] || {}]
   end

--- a/serverless-rack.gemspec
+++ b/serverless-rack.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'serverless-rack'
-  s.version     = '2.0.0'
+  s.version     = '2.0.1'
   s.summary     =
     'Serverless plugin to deploy Ruby Rack applications (Sinatra/Padrino/Cuba etc.) ' \
     'and bundle gems'

--- a/spec/parse_headers_spec.rb
+++ b/spec/parse_headers_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'parse_headers' do
     }
   end
 
-  it 'lower-cases keys', :aggregate_failures do
+  it 'responds to lower-case keys', :aggregate_failures do
     parsed_headers = parse_headers(event)
 
     expect(parsed_headers['header1']).to eq 'value1'
@@ -33,7 +33,7 @@ RSpec.describe 'parse_headers' do
       expect(parse_headers(event)['Header1']).to eq "value1\nvalue2"
     end
 
-    it 'lower-cases keys' do
+    it 'responds to lower-case keys' do
       expect(parse_headers(event)['header2']).to eq 'value3'
     end
   end

--- a/spec/parse_headers_spec.rb
+++ b/spec/parse_headers_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../lib/serverless_rack'
+
+RSpec.describe 'parse_headers' do
+  let(:event) do
+    {
+      'headers' => {
+        'Header1' => 'value1',
+        'HEADER2' => 'value2'
+      }
+    }
+  end
+
+  it 'lower-cases keys', :aggregate_failures do
+    parsed_headers = parse_headers(event)
+
+    expect(parsed_headers['header1']).to eq 'value1'
+    expect(parsed_headers['Header2']).to eq 'value2'
+  end
+
+  context 'with multiValuedHeaders' do
+    let(:event) do
+      {
+        'multiValueHeaders' => {
+          'Header1' => %w[value1 value2],
+          'HEADER2' => ['value3']
+        }
+      }
+    end
+
+    it 'joins the multi-value headers into a string' do
+      expect(parse_headers(event)['Header1']).to eq "value1\nvalue2"
+    end
+
+    it 'lower-cases keys' do
+      expect(parse_headers(event)['header2']).to eq 'value3'
+    end
+  end
+end


### PR DESCRIPTION
# Context

My Rack v3 updates unfortunately introduced a regression; when the event from the AWS ALB contains `multiValueHeaders`, the `parse_headers` method was essentially setting a default for the `Rack::Headers` instance it was returning via the `.new` constructor. It goes without saying that this isn't what we want! 

So we want a) test coverage to check that the `parse_header` method is doing what it should do and b) make sure to correctly initialise the `Rack::Headers` object when `multiValueHeaders` are present in the event object.

# Implementation

I've added unit tests for the `parse_headers` method; I'm happy with the coverage, and I've implement test-driven-development to make sure it caught the aforementioned issue.

The actual fix is easy; don't use `.new`, and just use the `[]` operator to create the `Rack::Header` instance instead.

# Patch version bump

I've opted to bump the version to `2.0.1`, as I consider this a straight-forward fix with no additional features.